### PR TITLE
Do not return replikator metrics if the call fails

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -123,7 +123,11 @@ func getMetrics() http.Handler {
 		var data replikatorData
 
 		output := execute("", "--output json --list")
-		json.Unmarshal([]byte(output), &data)
+		err := json.Unmarshal([]byte(output), &data)
+		if err != nil {
+			promhttp.Handler().ServeHTTP(w, r)
+			return
+		}
 
 		labels := prometheus.Labels{
 			"state": strings.ToLower(data.DatabaseGlobalState.ReplicationState),


### PR DESCRIPTION
Currently the metrics are reporting false data. This change will return no replikator metrics when the list command fails.